### PR TITLE
Enable support for new TLDs

### DIFF
--- a/lib/onetime/logic.rb
+++ b/lib/onetime/logic.rb
@@ -39,7 +39,7 @@ module Onetime
     class Base
       unless defined?(Onetime::Logic::Base::MOBILE_REGEX)
         MOBILE_REGEX = /^\+?\d{9,16}$/
-        EMAIL_REGEX = %r{^(?:[_a-z0-9-]+)(\.[_a-z0-9-]+)*@([a-z0-9-]+)(\.[a-zA-Z0-9\-\.]+)*(\.[a-z]{2,4})$}i
+        EMAIL_REGEX = %r{^(?:[_a-z0-9-]+)(\.[_a-z0-9-]+)*@([a-z0-9-]+)(\.[a-zA-Z0-9\-\.]+)*(\.[a-z]{2,})$}i
       end
       attr_reader :sess, :cust, :params, :locale, :processed_params, :plan
       def initialize(sess, cust, params=nil, locale=nil)


### PR DESCRIPTION
Like my business email-address: @mindkeeper.solutions

Registering at onetimesecret.com was formerly not possible due to my "invalid" email-address.
